### PR TITLE
Fix bug which allows user to create empty notes

### DIFF
--- a/src/NoteEditor.svelte
+++ b/src/NoteEditor.svelte
@@ -18,6 +18,8 @@
     function finishEdit() {
         var textbox = document.getElementById("note-text")
         
+        if (!textbox.value) return;
+
         editNote({
             content: textbox.value
         })


### PR DESCRIPTION
Add check for empty note in `NoteEditor.finishEdit`

Resolves #3